### PR TITLE
Add ALIS editor data-pipeline suite

### DIFF
--- a/src/plugins.ts
+++ b/src/plugins.ts
@@ -488,5 +488,6 @@ export const PLUGIN_DATA = [
 	"https://github.com/ArmainAP/Unreal-Engine-Widget-Spline-System",
 	"https://github.com/eanticev/niagara-destruction-driver",
 	"https://github.com/CommitAndChill/BlueprintTaskForge",
-	"https://github.com/Ciberusps/UHLDebugSystem"
+	"https://github.com/Ciberusps/UHLDebugSystem",
+	"https://github.com/fallintodusk/alis"
 ]


### PR DESCRIPTION
Adds ALIS's integrated UE5 editor data-pipeline suite, following the maintainer guidance in #13.

Repository:
https://github.com/fallintodusk/alis

Suggested representative plugin:
`Plugins/Editor/ProjectDefinitionGenerator/ProjectDefinitionGenerator.uplugin`

Architecture:
https://github.com/fallintodusk/alis/blob/main/docs/data/README.md

The repository README documents the complete suite: ProjectAssetSync, ProjectEditorCore, ProjectDefinitionGenerator, and ProjectPlacementEditor.